### PR TITLE
Abide by git's pager settings

### DIFF
--- a/git_pw/bundle.py
+++ b/git_pw/bundle.py
@@ -166,4 +166,4 @@ def list_cmd(owner, limit, page, sort, name):
         'yes' if bundle.get('public') else 'no',
     ] for bundle in bundles]
 
-    click.echo_via_pager(tabulate(output, headers, tablefmt='psql'))
+    utils.echo_via_pager(tabulate(output, headers, tablefmt='psql'))

--- a/git_pw/config.py
+++ b/git_pw/config.py
@@ -3,7 +3,8 @@ Configuration loader using 'git-config'.
 """
 
 import logging
-import subprocess
+
+from git_pw import utils
 
 LOG = logging.getLogger(__name__)
 # TODO(stephenfin): We should eventually download and store these
@@ -11,20 +12,6 @@ LOG = logging.getLogger(__name__)
 DEFAULT_STATES = [
     'new', 'under-review', 'accepted', 'rejected', 'rfc', 'not-applicable',
     'changes-requested', 'awaiting-upstream', 'superseded', 'deferred']
-
-
-def _get_config(key):
-    """Parse config from 'git-config' cache.
-
-    Returns:
-        Matching setting for 'key' if available, else None.
-    """
-    try:
-        output = subprocess.check_output(['git', 'config', 'pw.%s' % key])
-    except subprocess.CalledProcessError:
-        output = ''
-
-    return output.strip()
 
 
 class Config(object):
@@ -40,7 +27,7 @@ class Config(object):
             return value
 
         # fallback to reading from git config otherwise
-        value = _get_config(name)
+        value = utils.git_config('pw.{}'.format(name))
         if value:
             LOG.debug("Retrieved '{}' setting from git-config".format(name))
             value = value.decode('utf-8')

--- a/git_pw/patch.py
+++ b/git_pw/patch.py
@@ -274,4 +274,4 @@ def list_cmd(state, submitter, delegate, archived, limit, page, sort, name):
          if patch.get('delegate') else ''),
     ] for patch in patches]
 
-    click.echo_via_pager(tabulate(output, headers, tablefmt='psql'))
+    utils.echo_via_pager(tabulate(output, headers, tablefmt='psql'))

--- a/git_pw/series.py
+++ b/git_pw/series.py
@@ -155,4 +155,4 @@ def list_cmd(submitter, limit, page, sort, name):
                      series_.get('submitter').get('email'))
     ] for series_ in series]
 
-    click.echo_via_pager(tabulate(output, headers, tablefmt='psql'))
+    utils.echo_via_pager(tabulate(output, headers, tablefmt='psql'))

--- a/git_pw/tests/test_utils.py
+++ b/git_pw/tests/test_utils.py
@@ -1,10 +1,27 @@
 """Unit tests for ``git_pw/utils.py``."""
 
+import subprocess
 import os
 
 import mock
 
 from git_pw import utils
+
+
+@mock.patch.object(utils.subprocess, 'check_output', return_value=' bar ')
+def test_git_config(mock_subprocess):
+    value = utils.git_config('foo')
+
+    assert value == 'bar'
+    mock_subprocess.assert_called_once_with(['git', 'config', 'foo'])
+
+
+@mock.patch.object(utils.subprocess, 'check_output',
+                   side_effect=subprocess.CalledProcessError(1, 'xyz', '123'))
+def test_git_config_error(mock_subprocess):
+    value = utils.git_config('foo')
+
+    assert value == ''
 
 
 @mock.patch.object(utils, 'git_config', return_value='bar')

--- a/git_pw/tests/test_utils.py
+++ b/git_pw/tests/test_utils.py
@@ -1,0 +1,37 @@
+"""Unit tests for ``git_pw/utils.py``."""
+
+import os
+
+import mock
+
+from git_pw import utils
+
+
+@mock.patch.object(utils, 'git_config', return_value='bar')
+@mock.patch.object(utils, '_echo_via_pager')
+@mock.patch.dict(os.environ, {'GIT_PAGER': 'foo', 'PAGER': 'baz'})
+def test_echo_via_pager_env_GIT_PAGER(mock_inner, mock_config):
+    utils.echo_via_pager('test')
+
+    mock_config.assert_not_called()
+    mock_inner.assert_called_once_with('foo', 'test')
+
+
+@mock.patch.object(utils, 'git_config', return_value='bar')
+@mock.patch.object(utils, '_echo_via_pager')
+@mock.patch.dict(os.environ, {'PAGER': 'baz'})
+def test_echo_via_pager_config(mock_inner, mock_config):
+    utils.echo_via_pager('test')
+
+    mock_config.assert_called_once_with('core.parser')
+    mock_inner.assert_called_once_with('bar', 'test')
+
+
+@mock.patch.object(utils, 'git_config', return_value=None)
+@mock.patch.object(utils, '_echo_via_pager')
+@mock.patch.dict(os.environ, {'PAGER': 'baz'})
+def test_echo_via_pager_env_PAGER(mock_inner, mock_config):
+    utils.echo_via_pager('test')
+
+    mock_config.assert_called_once_with('core.parser')
+    mock_inner.assert_called_once_with('baz', 'test')

--- a/git_pw/utils.py
+++ b/git_pw/utils.py
@@ -2,6 +2,8 @@
 Utility functions.
 """
 
+import codecs
+import os
 import subprocess
 import sys
 
@@ -9,6 +11,20 @@ import sys
 def trim(string, length=70):  # type: (str, int) -> str
     """Trim a string to the given length."""
     return (string[:length - 1] + '...') if len(string) > length else string
+
+
+def git_config(value):
+    """Parse config from ``git-config`` cache.
+
+    Returns:
+        Matching setting for ``key`` if available, else None.
+    """
+    try:
+        output = subprocess.check_output(['git', 'config', value])
+    except subprocess.CalledProcessError:
+        output = ''
+
+    return output.strip()
 
 
 def git_am(mbox, args):
@@ -25,3 +41,75 @@ def git_am(mbox, args):
     except subprocess.CalledProcessError as exc:
         print(exc.output)
         sys.exit(exc.returncode)
+
+
+def _is_ascii_encoding(encoding):
+    """Checks if a given encoding is ascii."""
+    try:
+        return codecs.lookup(encoding).name == 'ascii'
+    except LookupError:
+        return False
+
+
+def _get_best_encoding(stream):
+    """Returns the default stream encoding if not found."""
+    rv = getattr(stream, 'encoding', None) or sys.getdefaultencoding()
+    if _is_ascii_encoding(rv):
+        return 'utf-8'
+    return rv
+
+
+def _echo_via_pager(pager, output):
+    env = dict(os.environ)
+    # When the LESS environment variable is unset, Git sets it to FRX (if
+    # LESS environment variable is set, Git does not change it at all).
+    if 'LESS' not in env:
+        env['LESS'] = 'FRX'
+
+    c = subprocess.Popen(pager, shell=True, stdin=subprocess.PIPE,
+                         env=env)
+    encoding = _get_best_encoding(c.stdin)
+
+    try:
+        for line in output:
+            c.stdin.write(line.encode(encoding, 'replace'))
+    except (IOError, KeyboardInterrupt):
+        pass
+    else:
+        c.stdin.close()
+
+    while True:
+        try:
+            c.wait()
+        except KeyboardInterrupt:
+            pass
+        else:
+            break
+
+
+def echo_via_pager(output):
+    """Echo using git's default pager.
+
+    Wrap ``click.echo_via_pager``, setting some environment variables in the
+    processs to mimic the pager settings used by Git:
+
+        The order of preference is the ``$GIT_PAGER`` environment variable,
+        then ``core.pager`` configuration, then ``$PAGER``, and then the
+        default chosen at compile time (usually ``less``).
+    """
+    pager = os.environ.get('GIT_PAGER', None)
+    if pager:
+        _echo_via_pager(pager, output)
+        return
+
+    pager = git_config('core.parser')
+    if pager:
+        _echo_via_pager(pager, output)
+        return
+
+    pager = os.environ.get('PAGER', None)
+    if pager:
+        _echo_via_pager(pager, output)
+        return
+
+    _echo_via_pager('less')

--- a/releasenotes/notes/use-git-pager-settings-ec6555d8311a8bec.yaml
+++ b/releasenotes/notes/use-git-pager-settings-ec6555d8311a8bec.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    *git-pw* will now choose use the same rules as Git to select the pager
+    used for ``list`` commands. This means the pager will be chosen based on a
+    variety of environment variables and git config options:
+
+        The order of preference is the ``$GIT_PAGER`` environment variable,
+        then ``core.pager`` configuration, then ``$PAGER``, and then the
+        default chosen at compile time (usually ``less``)


### PR DESCRIPTION
As noted in 'man git config', git uses a very specific sequence to
determine the pager used for output. Abide by these rules by providing
our own pager implementation.

Signed-off-by: Stephen Finucane <stephen@that.guru>
Closes: #16