### PR TITLE
Don't require escaping arguments

### DIFF
--- a/git_pw/bundle.py
+++ b/git_pw/bundle.py
@@ -35,9 +35,11 @@ def _get_bundle(bundle_id):
     return bundles[0]
 
 
-@click.command(name='apply')
+@click.command(name='apply', context_settings=dict(
+    ignore_unknown_options=True,
+))
 @click.argument('bundle_id')
-@click.argument('args', nargs=-1)
+@click.argument('args', nargs=-1, type=click.UNPROCESSED)
 def apply_cmd(bundle_id, args):
     """Apply bundle.
 

--- a/git_pw/bundle.py
+++ b/git_pw/bundle.py
@@ -43,7 +43,8 @@ def _get_bundle(bundle_id):
 def apply_cmd(bundle_id, args):
     """Apply bundle.
 
-    Apply a bundle locally using the 'git-am' command.
+    Apply a bundle locally using the 'git-am' command. Any additional ARGS
+    provided will be passed to the 'git-am' command.
     """
     LOG.debug('Applying bundle: id=%s', bundle_id)
 

--- a/git_pw/patch.py
+++ b/git_pw/patch.py
@@ -15,14 +15,16 @@ from git_pw import utils
 LOG = logging.getLogger(__name__)
 
 
-@click.command(name='apply')
+@click.command(name='apply', context_settings=dict(
+    ignore_unknown_options=True,
+))
 @click.argument('patch_id', type=click.INT)
 @click.option('--series', type=click.INT, metavar='SERIES',
               help='Series to include dependencies from. Defaults to latest.')
 @click.option('--deps/--no-deps', default=True,
               help='When applying the patch, include dependencies if '
               'available. Defaults to using the most recent series.')
-@click.argument('args', nargs=-1)
+@click.argument('args', nargs=-1, type=click.UNPROCESSED)
 def apply_cmd(patch_id, series, deps, args):
     """Apply patch.
 

--- a/git_pw/patch.py
+++ b/git_pw/patch.py
@@ -28,7 +28,8 @@ LOG = logging.getLogger(__name__)
 def apply_cmd(patch_id, series, deps, args):
     """Apply patch.
 
-    Apply a patch locally using the 'git-am' command.
+    Apply a patch locally using the 'git-am' command. Any additional ARGS
+    provided will be passed to the 'git-am' command.
     """
     LOG.debug('Applying patch: id=%d, series=%s, deps=%r, args=%s', patch_id,
               series, deps, ' '.join(args))

--- a/git_pw/series.py
+++ b/git_pw/series.py
@@ -15,9 +15,11 @@ from git_pw import utils
 LOG = logging.getLogger(__name__)
 
 
-@click.command(name='apply')
+@click.command(name='apply', context_settings=dict(
+    ignore_unknown_options=True,
+))
 @click.argument('series_id', type=click.INT)
-@click.argument('args', nargs=-1)
+@click.argument('args', nargs=-1, type=click.UNPROCESSED)
 def apply_cmd(series_id, args):
     """Apply series.
 

--- a/git_pw/series.py
+++ b/git_pw/series.py
@@ -23,7 +23,8 @@ LOG = logging.getLogger(__name__)
 def apply_cmd(series_id, args):
     """Apply series.
 
-    Apply a series locally using the 'git-am' command.
+    Apply a series locally using the 'git-am' command. Any additional ARGS
+    provided will be passed to the 'git-am' command.
     """
     LOG.debug('Applying series: id=%d, args=%s', series_id, ' '.join(args))
 

--- a/releasenotes/notes/passthrough-git-am-arguments-23cd0b292304d648.yaml
+++ b/releasenotes/notes/passthrough-git-am-arguments-23cd0b292304d648.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    ``git pw patch apply``, ``git pw bundle apply`` and ``git pw series apply``
+    will now pass any additional arugments provided through to ``git am``. For
+    example::
+
+        $ git pw patch apply 123 --signoff
+
+    Previously it was necessary to escape these arguments with ``--``.


### PR DESCRIPTION
It's helpful being able to pass through additional arguments to 'git-am', where it's used. We've supported this since 1.0 but we needed to escape these arguments like so:

    git-am apply 123 -- --signoff 123

This is, as seen in #19 and #20, not very intuitive. Remove the need to do this. Note that some arguments - notably '--help' - may need to be escaped as before to prevent our own parser swallowing them.

Closes #19, Closes #20