### PR TITLE
Fix help text for --format to refer to pw.format

### DIFF
--- a/git_pw/utils.py
+++ b/git_pw/utils.py
@@ -174,7 +174,7 @@ def format_options(original_function=None, headers=None):
         f = click.option('--format', '-f', 'fmt', default=None,
                          type=click.Choice(['simple', 'table', 'csv']),
                          help="Output format. Defaults to the value of "
-                         "'git config pw.server' else 'table'.")(f)
+                         "'git config pw.format' else 'table'.")(f)
 
         if headers:
             f = click.option('--column', '-c', 'headers', metavar='COLUMN',


### PR DESCRIPTION
The help text for --format says that it's controlled by pw.server, but
that's wrong, it's controlled by pw.format.

Signed-off-by: Michael Ellerman <mpe@ellerman.id.au>