### PR TITLE
Allow optional authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ settings are **required**:
 
       https://patchwork.ozlabs.org/project/{project_name}/list/
 
-You also require authentication - you can use either API tokens or a
+If you also require authentication - you can use either API tokens or a
 username/password combination:
 
 ``pw.token``

--- a/git_pw/api.py
+++ b/git_pw/api.py
@@ -40,16 +40,12 @@ class HTTPTokenAuth(requests.auth.AuthBase):
         return 'Token {}'.format(token.strip())
 
 
-def _get_auth():  # type: () -> requests.auth.AuthBase
+def _get_auth():  # type: () -> Optional[requests.auth.AuthBase]
     if CONF.token:
         return HTTPTokenAuth(CONF.token)
     elif CONF.username and CONF.password:
         return requests.auth.HTTPBasicAuth(CONF.username, CONF.password)
-    else:
-        LOG.error('Authentication information missing')
-        LOG.error('You must configure authentication via git-config or via '
-                  '--token or --username, --password')
-        sys.exit(1)
+    return None
 
 
 def _get_headers():  # type: () -> Dict[str, str]


### PR DESCRIPTION
This patch allows using git-pw without requiring authentication since some Patchwork configurations don't require authentication to access their API.