### PR TITLE
Print git-am output

### DIFF
--- a/git_pw/utils.py
+++ b/git_pw/utils.py
@@ -2,6 +2,7 @@
 Utility functions.
 """
 
+from __future__ import print_function
 import codecs
 import os
 import subprocess
@@ -46,10 +47,12 @@ def git_am(mbox, args):
     cmd.append(mbox)
 
     try:
-        subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:
         print(exc.output)
         sys.exit(exc.returncode)
+    else:
+        print(output, end='')
 
 
 def _tabulate(output, headers, fmt):


### PR DESCRIPTION
This commit changes the {series,patch,bundle} apply command
to print the git-am output, thus showing the same result as the
use of git-am would produce.

This is specially useful when applying series.

Before this commit, git-pw would show nothing:

```
$ git-pw --project linux-input series apply 87107
$ (nothing printed)
```

After this commit:

```
$ git-pw --project linux-input series apply 87107
Applying: HID: intel-ish-hid: Add match callback to ishtp bus type
Applying: HID: intel-ish-hid: Hide members of struct ishtp_cl_device
Applying: HID: intel-ish-hid: Simplify ishtp_cl_link()
Applying: HID: intel-ish-hid: Move driver registry functions
Applying: HID: intel-ish-hid: Store ishtp_cl_device instance in device
Applying: HID: intel-ish-hid: Move the common functions from client.h
Applying: HID: intel-ish-hid: Add interface functions for struct ishtp_cl
Applying: HID: intel-ish-hid: Move functions related to bus and device
Applying: HID: intel-ish-hid: Use the new interface functions in HID ish client
$
```

If a patch in a series does not apply cleanly, it's useful
to get some output of those that did apply. Also, having a git-am-like
output improves the user experience, by providing a more familiar
feeling.

Signed-off-by: Ezequiel Garcia <ezequiel@collabora.com>