### PR TITLE
utils: Fix git-am output

### DIFF
--- a/git_pw/utils.py
+++ b/git_pw/utils.py
@@ -49,10 +49,10 @@ def git_am(mbox, args):
     try:
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:
-        print(exc.output)
+        print(exc.output.decode('utf-8'))
         sys.exit(exc.returncode)
     else:
-        print(output, end='')
+        print(output.decode('utf-8'), end='')
 
 
 def _tabulate(output, headers, fmt):


### PR DESCRIPTION
Add .decode('utf-8') so when we print git-am output, or git-am errors, we
print a string, rather than a bytes object.

Signed-off-by: Andrew Donnellan <ajd@linux.ibm.com>