### PR TITLE
Fix the setup.py warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = git-pw
 summary = Git-Patchwork integration tool
-description-file = README.rst
+description_file = README.rst
 license = MIT License
 license_file = LICENSE
 classifiers =


### PR DESCRIPTION
Fix following Warning:
 Usage of dash-separated 'description-file' will not be supported in future versions.
 Please use the underscore name 'description_file' instead

Signed-off-by: Yixun Lan <dlan@gentoo.org>