### PR TITLE
Resolve #27 by adding '--since' and '--before' options

### DIFF
--- a/git_pw/patch.py
+++ b/git_pw/patch.py
@@ -329,6 +329,7 @@ def update_cmd(patch_ids, commit_ref, state, delegate, archived, fmt):
     is_flag=True,
     help='Include patches that are archived.',
 )
+@utils.date_options()
 @utils.pagination_options(sort_fields=_sort_fields, default_sort='-date')
 @utils.format_options(headers=_list_headers)
 @click.argument('name', required=False)
@@ -339,6 +340,8 @@ def list_cmd(
     delegates,
     hashes,
     archived,
+    since,
+    before,
     limit,
     page,
     sort,
@@ -402,6 +405,12 @@ def list_cmd(
             ('order', sort),
         ]
     )
+
+    if since:
+        params.append(('since', since.isoformat()))
+
+    if before:
+        params.append(('before', before.isoformat()))
 
     patches = api.index('patches', params)
 

--- a/git_pw/series.py
+++ b/git_pw/series.py
@@ -161,11 +161,12 @@ def show_cmd(fmt, series_id):
         'email, name or ID.'
     ),
 )
+@utils.date_options()
 @utils.pagination_options(sort_fields=_sort_fields, default_sort='-date')
 @utils.format_options(headers=_list_headers)
 @click.argument('name', required=False)
 @api.validate_multiple_filter_support
-def list_cmd(submitters, limit, page, sort, fmt, headers, name):
+def list_cmd(submitters, limit, page, sort, fmt, headers, name, since, before):
     """List series.
 
     List series on the Patchwork instance.
@@ -200,6 +201,12 @@ def list_cmd(submitters, limit, page, sort, fmt, headers, name):
             ('order', sort),
         ]
     )
+
+    if since:
+        params.append(('since', since.isoformat()))
+
+    if before:
+        params.append(('before', before.isoformat()))
 
     series = api.index('series', params)
 

--- a/git_pw/utils.py
+++ b/git_pw/utils.py
@@ -207,6 +207,28 @@ def pagination_options(
     return _pagination_options
 
 
+def date_options() -> ty.Callable:
+    """Shared date bounding options."""
+
+    def _date_options(f):
+        f = click.option(
+            '--since',
+            metavar='SINCE',
+            type=click.DateTime(),
+            help='Show only items since a given date in ISO 8601 format',
+        )(f)
+        f = click.option(
+            '--before',
+            metavar='BEFORE',
+            type=click.DateTime(),
+            help='Show only items before a given date in ISO 8601 format',
+        )(f)
+
+        return f
+
+    return _date_options
+
+
 def format_options(
     original_function: ty.Optional[ty.Callable] = None,
     headers: ty.Optional[ty.Tuple[str, ...]] = None,

--- a/releasenotes/notes/add-before-since-options-c67799ef2ad89c0c.yaml
+++ b/releasenotes/notes/add-before-since-options-c67799ef2ad89c0c.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The ``series list`` and ``patch list`` commands now support ``--since`` and
+    ``--before`` filters to list items created since or before a given
+    date-time.

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -391,6 +391,10 @@ class ListTestCase(unittest.TestCase):
                 '--sort',
                 '-name',
                 'test',
+                '--since',
+                '2022-01-01',
+                '--before',
+                '2022-12-31',
             ],
         )
 
@@ -412,6 +416,8 @@ class ListTestCase(unittest.TestCase):
                     ('page', 1),
                     ('per_page', 1),
                     ('order', '-name'),
+                    ('since', '2022-01-01T00:00:00'),
+                    ('before', '2022-12-31T00:00:00'),
                 ],
             ),
         ]

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -226,6 +226,10 @@ class ListTestCase(unittest.TestCase):
                 '--sort',
                 '-name',
                 'test',
+                '--since',
+                '2022-01-01',
+                '--before',
+                '2022-12-31',
             ],
         )
 
@@ -241,6 +245,8 @@ class ListTestCase(unittest.TestCase):
                     ('page', 1),
                     ('per_page', 1),
                     ('order', '-name'),
+                    ('since', '2022-01-01T00:00:00'),
+                    ('before', '2022-12-31T00:00:00'),
                 ],
             ),
         ]


### PR DESCRIPTION
Hello,

I've been working on adding support for bounding patch and series list results with the use of --before and --since options to git-pw. This is of particular value to our use with the Yocto Project, but others may find it very helpful as well. I saw that there is an open issue (#27) where this feature has been discussed before, so hopefully this change could solve that issue.

What I'm not clear on is how to add proper tests - I've skimmed the existing test cases but I'm not understanding how the mock operates. Would testing these options fit easily into what exists? If so, could you provide suggestions?

Thanks!
-Trevor