### PR TITLE
Support applying series dependencies

### DIFF
--- a/git_pw/api.py
+++ b/git_pw/api.py
@@ -232,6 +232,11 @@ def version() -> ty.Tuple[int, int]:
     return (1, 0)
 
 
+def get(url: str, params: ty.Optional[Filters]) -> ty.Dict:
+    """Get a JSON document from the API and return it as a dict."""
+    return _get(url, params, stream=False).json()
+
+
 def download(
     url: str,
     params: ty.Optional[Filters] = None,


### PR DESCRIPTION
This change adds a switch to the apply sub-command that, when present, will download and apply all series which the series given on the command line depends on before applying said series. When the switch is not present, the original behavior is conserved. A warning is printed if the user requests to apply dependencies for a patch but the server/project does not support dependencies.